### PR TITLE
Fix typo in CODEOWNERS for SindreWinaes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @SlimNinjaRuu @SindreWinaes


### PR DESCRIPTION
Fixed so that SlimNinjaRuu and SindreWineas are CODEOWNERS